### PR TITLE
Add url to Attachments returned by message.listAttachments function 

### DIFF
--- a/mail/components/extensions/parent/ext-messages.js
+++ b/mail/components/extensions/parent/ext-messages.js
@@ -68,6 +68,7 @@ function convertAttachment(attachment) {
     name: attachment.name,
     size: attachment.size,
     partName: attachment.partName,
+    url: attachment.url,
   };
 }
 


### PR DESCRIPTION
This way it can be send through messages to contentScript for display in the message context.

Tried it and worked like a charm.

Regards,